### PR TITLE
Add configurable two-player board game tooling

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -11,10 +11,52 @@
 <body>
 
     <h1>谁都可以用的微缩盲道迷宫设计器</h1>
-    <p>从左侧工具栏选择一个样式，然后在右侧网格上点击即可应用。如需导出请截图。</p>
+    <p>使用左侧工具箱设计桌游。先用黑色摆放得分块与障碍，再设置双方棋子数量，选择颜色并放置行进盲道与提示盲道。</p>
 
     <div class="controls">
-        <button id="reset-button">清空重置</button>
+        <div class="control-group">
+            <button id="reset-button">清空网格</button>
+            <button id="restart-button">重新开始</button>
+        </div>
+        <div class="control-group color-picker">
+            <span>当前颜色：</span>
+            <label><input type="radio" name="color" value="black" checked>黑色</label>
+            <label><input type="radio" name="color" value="red">红色</label>
+            <label><input type="radio" name="color" value="blue">蓝色</label>
+        </div>
+        <div class="control-group rotation-controls">
+            <button id="rotate-left" type="button">↺ 逆时针</button>
+            <span id="rotation-indicator">角度：0°</span>
+            <button id="rotate-right" type="button">顺时针 ↻</button>
+        </div>
+    </div>
+
+    <div class="inventory-panel">
+        <form id="inventory-form">
+            <h2>设置双方可用棋子数量</h2>
+            <div class="inventory-grid">
+                <div class="inventory-player" data-player="red">
+                    <h3>红方</h3>
+                    <label>行进盲道（1格）<input type="number" name="red-walkway-1" min="0" value="6"></label>
+                    <label>行进盲道（2格）<input type="number" name="red-walkway-2" min="0" value="6"></label>
+                    <label>行进盲道（3格）<input type="number" name="red-walkway-3" min="0" value="6"></label>
+                    <label>提示盲道（折角）<input type="number" name="red-hint-corner" min="0" value="4"></label>
+                    <label>提示盲道（T 型）<input type="number" name="red-hint-t" min="0" value="3"></label>
+                    <label>提示盲道（X 型）<input type="number" name="red-hint-x" min="0" value="2"></label>
+                </div>
+                <div class="inventory-player" data-player="blue">
+                    <h3>蓝方</h3>
+                    <label>行进盲道（1格）<input type="number" name="blue-walkway-1" min="0" value="6"></label>
+                    <label>行进盲道（2格）<input type="number" name="blue-walkway-2" min="0" value="6"></label>
+                    <label>行进盲道（3格）<input type="number" name="blue-walkway-3" min="0" value="6"></label>
+                    <label>提示盲道（折角）<input type="number" name="blue-hint-corner" min="0" value="4"></label>
+                    <label>提示盲道（T 型）<input type="number" name="blue-hint-t" min="0" value="3"></label>
+                    <label>提示盲道（X 型）<input type="number" name="blue-hint-x" min="0" value="2"></label>
+                </div>
+            </div>
+            <button type="submit">设置棋子数量并开始游戏</button>
+        </form>
+        <div id="inventory-display" aria-live="polite"></div>
     </div>
 
     <div class="main-content">

--- a/web/script.js
+++ b/web/script.js
@@ -1,98 +1,328 @@
 document.addEventListener('DOMContentLoaded', () => {
-    // --- 配置区域 ---
     const GRID_COLS = 42;
     const GRID_ROWS = 28;
-    const NUM_STATES = 5;
+
+    const TILE_TYPES = [
+        { id: 'empty', name: '清空', label: '清', shape: [[0, 0]], category: 'basic', consumesInventory: false },
+        { id: 'obstacle', name: '障碍物', label: '障', shape: [[0, 0]], category: 'basic', consumesInventory: false },
+        { id: 'score-1', name: '1 分得分块（4 格）', label: '1分', shape: [[0, 0], [1, 0], [0, 1], [1, 1]], category: 'score', consumesInventory: false },
+        { id: 'score-2', name: '2 分得分块（2 格）', label: '2分', shape: [[0, 0], [1, 0]], category: 'score', consumesInventory: false },
+        { id: 'score-3', name: '3 分得分块（2 格）', label: '3分', shape: [[0, 0], [1, 0]], category: 'score', consumesInventory: false },
+        { id: 'score-4', name: '4 分得分块（1 格）', label: '4分', shape: [[0, 0]], category: 'score', consumesInventory: false },
+        { id: 'score-5', name: '5 分得分块（1 格）', label: '5分', shape: [[0, 0]], category: 'score', consumesInventory: false },
+        { id: 'walkway-1', name: '行进盲道（1 格）', label: '行1', shape: [[0, 0]], category: 'walkway', consumesInventory: true, inventoryKey: 'walkway-1' },
+        { id: 'walkway-2', name: '行进盲道（2 格）', label: '行2', shape: [[0, 0], [1, 0]], category: 'walkway', consumesInventory: true, inventoryKey: 'walkway-2' },
+        { id: 'walkway-3', name: '行进盲道（3 格）', label: '行3', shape: [[0, 0], [1, 0], [2, 0]], category: 'walkway', consumesInventory: true, inventoryKey: 'walkway-3' },
+        { id: 'hint-corner', name: '提示盲道（折角，3 格）', label: '折', shape: [[0, 0], [1, 0], [0, 1]], category: 'hint', consumesInventory: true, inventoryKey: 'hint-corner' },
+        { id: 'hint-t', name: '提示盲道（T 型，4 格）', label: 'T', shape: [[0, 0], [-1, 0], [1, 0], [0, 1]], category: 'hint', consumesInventory: true, inventoryKey: 'hint-t' },
+        { id: 'hint-x', name: '提示盲道（X 型，5 格）', label: 'X', shape: [[0, 0], [1, 0], [-1, 0], [0, 1], [0, -1]], category: 'hint', consumesInventory: true, inventoryKey: 'hint-x' },
+    ];
+
+    const CATEGORIES = [
+        { id: 'basic', title: '基础工具' },
+        { id: 'score', title: '得分块' },
+        { id: 'walkway', title: '行进盲道' },
+        { id: 'hint', title: '提示盲道' },
+    ];
+
+    const INVENTORY_KEYS = ['walkway-1', 'walkway-2', 'walkway-3', 'hint-corner', 'hint-t', 'hint-x'];
 
     // --- 全局变量 ---
-    let selectedState = 1; // 默认选中的状态 (1: 斜线)
+    let selectedTileId = 'score-1';
+    let currentRotation = 0; // 以度数表示
+    let currentColor = 'black';
+    let inventoryEnabled = false;
+    let inventory = createEmptyInventory();
 
     // --- 获取 DOM 元素 ---
     const gridContainer = document.getElementById('grid-container');
     const paletteContainer = document.getElementById('palette');
     const resetButton = document.getElementById('reset-button');
+    const restartButton = document.getElementById('restart-button');
+    const rotationIndicator = document.getElementById('rotation-indicator');
+    const rotateLeftButton = document.getElementById('rotate-left');
+    const rotateRightButton = document.getElementById('rotate-right');
+    const inventoryForm = document.getElementById('inventory-form');
+    const inventoryDisplay = document.getElementById('inventory-display');
+
+    // --- 初始化 ---
+    createPalette();
+    createGrid();
+    updateRotationIndicator();
+    updateInventoryDisplay();
+
+    // --- 事件绑定 ---
+    resetButton.addEventListener('click', () => resetGrid());
+    restartButton.addEventListener('click', () => restartGame());
+    rotateLeftButton.addEventListener('click', () => rotate(-90));
+    rotateRightButton.addEventListener('click', () => rotate(90));
+
+    document.querySelectorAll('input[name="color"]').forEach(radio => {
+        radio.addEventListener('change', event => {
+            currentColor = event.target.value;
+        });
+    });
+
+    inventoryForm.addEventListener('submit', event => {
+        event.preventDefault();
+        applyInventorySettings(new FormData(inventoryForm));
+    });
 
     // --- 函数定义 ---
 
-    /**
-     * 创建左侧的调色板
-     */
     function createPalette() {
-        for (let i = 0; i < NUM_STATES; i++) {
-            const paletteCell = document.createElement('div');
-            paletteCell.classList.add('palette-cell', `state-${i}`);
-            paletteCell.dataset.state = i;
+        paletteContainer.innerHTML = '';
+        CATEGORIES.forEach(category => {
+            const section = document.createElement('div');
+            section.classList.add('palette-section');
 
-            // 默认选中第一个非空格的状态
-            if (i === selectedState) {
-                paletteCell.classList.add('selected');
-            }
+            const title = document.createElement('h3');
+            title.textContent = category.title;
+            section.appendChild(title);
 
-            paletteCell.addEventListener('click', handlePaletteClick);
-            paletteContainer.appendChild(paletteCell);
-        }
-    }
+            const grid = document.createElement('div');
+            grid.classList.add('palette-grid');
 
-    /**
-     * 创建并初始化网格
-     */
-    function createGrid() {
-        gridContainer.innerHTML = ''; // 清空现有网格
-        for (let i = 0; i < GRID_ROWS * GRID_COLS; i++) {
-            const cell = document.createElement('div');
-            cell.classList.add('grid-cell', 'state-0'); // 所有格子默认是状态0 (空白)
-            cell.dataset.state = 0;
-            cell.addEventListener('click', handleCellClick);
-            gridContainer.appendChild(cell);
-        }
-    }
+            TILE_TYPES.filter(tile => tile.category === category.id).forEach(tile => {
+                const cell = document.createElement('div');
+                cell.classList.add('palette-cell', `tile-${tile.id}`, 'color-black');
+                cell.dataset.tileId = tile.id;
+                cell.dataset.label = tile.label;
+                cell.title = tile.name;
+                if (tile.id === selectedTileId) {
+                    cell.classList.add('selected');
+                }
+                cell.addEventListener('click', () => handlePaletteSelection(cell));
+                grid.appendChild(cell);
+            });
 
-    /**
-     * 处理调色板点击事件
-     * @param {MouseEvent} event 
-     */
-    function handlePaletteClick(event) {
-        // 更新全局选中的状态
-        selectedState = parseInt(event.target.dataset.state, 10);
-
-        // 更新调色板的视觉效果
-        document.querySelectorAll('.palette-cell').forEach(cell => {
-            cell.classList.remove('selected');
+            section.appendChild(grid);
+            paletteContainer.appendChild(section);
         });
-        event.target.classList.add('selected');
     }
 
-    /**
-     * 处理网格单元格点击事件
-     * @param {MouseEvent} event 
-     */
-    function handleCellClick(event) {
-        const cell = event.target;
-        const currentState = parseInt(cell.dataset.state, 10);
-
-        // 移除旧的状态
-        cell.classList.remove(`state-${currentState}`);
-
-        // 应用当前在调色板中选中的状态
-        cell.classList.add(`state-${selectedState}`);
-        cell.dataset.state = selectedState;
-    }
-
-    /**
-     * 清空网格状态并重置
-     */
-    function resetGrid() {
-        if (confirm('确定要清空所有格子的状态吗？这个操作无法撤销。')) {
-            // 只需重新创建一遍网格即可
-            createGrid();
-            alert('网格已重置。');
+    function createGrid() {
+        gridContainer.innerHTML = '';
+        for (let row = 0; row < GRID_ROWS; row++) {
+            for (let col = 0; col < GRID_COLS; col++) {
+                const cell = document.createElement('div');
+                cell.classList.add('grid-cell', 'tile-empty', 'color-black');
+                cell.dataset.row = row;
+                cell.dataset.col = col;
+                cell.dataset.tileId = 'empty';
+                cell.dataset.color = 'black';
+                cell.addEventListener('click', handleCellClick);
+                gridContainer.appendChild(cell);
+            }
         }
     }
 
-    // --- 事件监听 ---
-    resetButton.addEventListener('click', resetGrid);
+    function handlePaletteSelection(cell) {
+        selectedTileId = cell.dataset.tileId;
+        document.querySelectorAll('.palette-cell').forEach(paletteCell => {
+            paletteCell.classList.remove('selected');
+        });
+        cell.classList.add('selected');
+    }
 
-    // --- 初始加载 ---
-    createPalette(); // 先创建调色板
-    createGrid();    // 再创建网格
+    function handleCellClick(event) {
+        const cell = event.currentTarget;
+        const tile = TILE_TYPES.find(t => t.id === selectedTileId);
+        if (!tile) return;
+
+        const baseRow = parseInt(cell.dataset.row, 10);
+        const baseCol = parseInt(cell.dataset.col, 10);
+
+        if (!canPlaceTile(tile, baseRow, baseCol)) {
+            alert('该位置无法完整放下当前棋子，请选择其他格子或旋转后再试。');
+            return;
+        }
+
+        if (!consumeInventoryIfNeeded(tile)) {
+            return;
+        }
+
+        applyTile(tile, baseRow, baseCol);
+        checkGameEnd();
+    }
+
+    function rotate(delta) {
+        currentRotation = (currentRotation + delta) % 360;
+        if (currentRotation < 0) {
+            currentRotation += 360;
+        }
+        updateRotationIndicator();
+    }
+
+    function updateRotationIndicator() {
+        rotationIndicator.textContent = `角度：${currentRotation}°`;
+    }
+
+    function resetGrid(skipConfirm = false) {
+        if (!skipConfirm && !confirm('确定要清空整个网格吗？')) {
+            return;
+        }
+        Array.from(gridContainer.children).forEach(cell => {
+            setCellState(cell, 'empty', 'black');
+        });
+    }
+
+    function restartGame() {
+        if (!confirm('重新开始会清空网格并重置棋子数量，确定吗？')) {
+            return;
+        }
+        inventoryForm.reset();
+        inventoryEnabled = false;
+        inventory = createEmptyInventory();
+        updateInventoryDisplay();
+        currentColor = 'black';
+        document.querySelector('input[name="color"][value="black"]').checked = true;
+        currentRotation = 0;
+        updateRotationIndicator();
+        document.querySelectorAll('.palette-cell').forEach(cell => cell.classList.remove('selected'));
+        selectedTileId = 'score-1';
+        const defaultSelected = document.querySelector('.palette-cell[data-tile-id="score-1"]');
+        if (defaultSelected) {
+            defaultSelected.classList.add('selected');
+        }
+        resetGrid(true);
+    }
+
+    function applyInventorySettings(formData) {
+        const newInventory = createEmptyInventory();
+        ['red', 'blue'].forEach(color => {
+            INVENTORY_KEYS.forEach(key => {
+                const formKey = `${color}-${key}`;
+                const value = parseInt(formData.get(formKey), 10);
+                newInventory[color][key] = Number.isFinite(value) && value >= 0 ? value : 0;
+            });
+        });
+        inventory = newInventory;
+        inventoryEnabled = true;
+        updateInventoryDisplay();
+        alert('棋子数量已设置，游戏开始！');
+    }
+
+    function updateInventoryDisplay() {
+        if (!inventoryEnabled) {
+            inventoryDisplay.innerHTML = '<p>请设置红蓝双方的棋子数量以开始游戏。</p>';
+            return;
+        }
+
+        const rows = INVENTORY_KEYS.map(key => {
+            const name = getInventoryName(key);
+            return `<tr><td>${name}</td><td>${inventory.red[key]}</td><td>${inventory.blue[key]}</td></tr>`;
+        }).join('');
+
+        inventoryDisplay.innerHTML = `
+            <table>
+                <thead>
+                    <tr><th>棋子</th><th>红方剩余</th><th>蓝方剩余</th></tr>
+                </thead>
+                <tbody>
+                    ${rows}
+                </tbody>
+            </table>
+        `;
+    }
+
+    function getInventoryName(key) {
+        switch (key) {
+            case 'walkway-1': return '行进盲道（1 格）';
+            case 'walkway-2': return '行进盲道（2 格）';
+            case 'walkway-3': return '行进盲道（3 格）';
+            case 'hint-corner': return '提示盲道（折角）';
+            case 'hint-t': return '提示盲道（T 型）';
+            case 'hint-x': return '提示盲道（X 型）';
+            default: return key;
+        }
+    }
+
+    function createEmptyInventory() {
+        const result = { red: {}, blue: {} };
+        ['red', 'blue'].forEach(color => {
+            INVENTORY_KEYS.forEach(key => {
+                result[color][key] = 0;
+            });
+        });
+        return result;
+    }
+
+    function canPlaceTile(tile, baseRow, baseCol) {
+        const offsets = getRotatedOffsets(tile.shape);
+        return offsets.every(([dx, dy]) => {
+            const targetCol = baseCol + dx;
+            const targetRow = baseRow + dy;
+            return targetCol >= 0 && targetCol < GRID_COLS && targetRow >= 0 && targetRow < GRID_ROWS;
+        });
+    }
+
+    function consumeInventoryIfNeeded(tile) {
+        if (!tile.consumesInventory || currentColor === 'black') {
+            return true;
+        }
+        if (!inventoryEnabled) {
+            return true;
+        }
+        const remaining = inventory[currentColor][tile.inventoryKey];
+        if (remaining <= 0) {
+            alert(`${currentColor === 'red' ? '红方' : '蓝方'}的该类型棋子已用完。`);
+            return false;
+        }
+        inventory[currentColor][tile.inventoryKey] -= 1;
+        updateInventoryDisplay();
+        return true;
+    }
+
+    function applyTile(tile, baseRow, baseCol) {
+        const offsets = getRotatedOffsets(tile.shape);
+        const colorToApply = tile.id === 'empty' ? 'black' : currentColor;
+
+        const cells = offsets.map(([dx, dy]) => {
+            const targetCol = baseCol + dx;
+            const targetRow = baseRow + dy;
+            const index = targetRow * GRID_COLS + targetCol;
+            return gridContainer.children[index];
+        });
+
+        cells.forEach(cell => setCellState(cell, tile.id, colorToApply));
+    }
+
+    function setCellState(cell, tileId, color) {
+        cell.className = 'grid-cell';
+        cell.classList.add(`tile-${tileId}`, `color-${color}`);
+        cell.dataset.tileId = tileId;
+        cell.dataset.color = color;
+    }
+
+    function getRotatedOffsets(shape) {
+        const normalizedRotation = ((currentRotation % 360) + 360) % 360;
+        return shape.map(([x, y]) => {
+            switch (normalizedRotation) {
+                case 90:
+                    return [y, -x];
+                case 180:
+                    return [-x, -y];
+                case 270:
+                    return [-y, x];
+                default:
+                    return [x, y];
+            }
+        });
+    }
+
+    function checkGameEnd() {
+        if (!inventoryEnabled) {
+            return;
+        }
+        const redRemaining = sumInventory(inventory.red);
+        const blueRemaining = sumInventory(inventory.blue);
+        if (redRemaining === 0 && blueRemaining === 0) {
+            alert('所有棋子已放完，游戏结束！可以重新开始或调整配置。');
+        }
+    }
+
+    function sumInventory(store) {
+        return Object.values(store).reduce((sum, value) => sum + value, 0);
+    }
 });

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,66 +1,194 @@
 /* 整体页面样式 */
 body {
-    font-family: sans-serif;
+    font-family: "Noto Sans SC", "Microsoft Yahei", sans-serif;
     background-color: #f0f0f0;
     color: #333;
     text-align: center;
     padding: 20px;
 }
 
-/* 控制按钮区域样式 */
-.controls {
+h1 {
+    margin-bottom: 10px;
+}
+
+p {
     margin-bottom: 20px;
 }
 
+/* 控制按钮区域样式 */
+.controls {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 20px;
+    margin-bottom: 20px;
+}
+
+.control-group {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
 button {
-    padding: 10px 20px;
-    font-size: 16px;
+    padding: 10px 16px;
+    font-size: 15px;
     cursor: pointer;
     border: 1px solid #ccc;
-    border-radius: 5px;
-    margin: 0 10px;
+    border-radius: 6px;
     background-color: #fff;
+    transition: background-color 0.2s ease;
 }
 
 button:hover {
     background-color: #e9e9e9;
 }
 
+.color-picker span {
+    font-weight: bold;
+}
+
+.rotation-controls span {
+    font-weight: bold;
+    min-width: 96px;
+    text-align: center;
+}
+
+/* 棋子数量设置 */
+.inventory-panel {
+    max-width: 960px;
+    margin: 0 auto 24px auto;
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 10px;
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+    text-align: left;
+}
+
+.inventory-panel h2 {
+    margin-top: 0;
+    text-align: center;
+}
+
+.inventory-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 20px;
+    margin-bottom: 20px;
+}
+
+.inventory-player {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    background-color: #f7f7f7;
+    border-radius: 8px;
+    padding: 12px 16px;
+}
+
+.inventory-player h3 {
+    margin: 0 0 6px 0;
+    text-align: center;
+}
+
+.inventory-player label {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 14px;
+}
+
+.inventory-player input[type="number"] {
+    width: 80px;
+    padding: 4px;
+}
+
+#inventory-display {
+    margin-top: 10px;
+    font-size: 14px;
+    line-height: 1.6;
+}
+
+#inventory-display table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+#inventory-display th,
+#inventory-display td {
+    border: 1px solid #ddd;
+    padding: 6px 4px;
+    text-align: center;
+    font-size: 13px;
+}
+
+#inventory-display thead {
+    background-color: #f0f3f6;
+}
+
 /* 新增：主内容区，使用 Flex 布局让调色板和网格并排 */
 .main-content {
     display: flex;
     justify-content: center;
-    /* 水平居中 */
     align-items: flex-start;
-    /* 顶部对齐 */
     gap: 20px;
-    /* 调色板和网格之间的间距 */
 }
 
-/* 新增：左侧调色板容器样式 */
+/* 调色板布局 */
 #palette {
     display: flex;
     flex-direction: column;
-    /* 让工具竖向排列 */
-    gap: 10px;
-    /* 工具之间的间距 */
+    gap: 16px;
+    max-height: 640px;
+    overflow-y: auto;
+    padding-right: 10px;
 }
 
-/* 新增：调色板中的单个工具样式 */
+.palette-section {
+    background-color: #fff;
+    border-radius: 10px;
+    padding: 12px;
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.08);
+    width: 220px;
+}
+
+.palette-section h3 {
+    margin: 0 0 8px 0;
+    font-size: 16px;
+}
+
+.palette-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
+}
+
 .palette-cell {
-    width: 50px;
-    height: 50px;
+    width: 60px;
+    height: 60px;
     background-size: cover;
+    background-position: center;
     border: 3px solid #ccc;
-    border-radius: 5px;
+    border-radius: 8px;
     cursor: pointer;
-    background-color: white;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-weight: bold;
+    color: rgba(255, 255, 255, 0.9);
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
 }
 
-/* 新增：当某个工具被选中时的样式 */
+.palette-cell::after {
+    content: attr(data-label);
+}
+
 .palette-cell.selected {
     border-color: #007bff;
-    /* 使用蓝色高亮显示 */
     box-shadow: 0 0 10px rgba(0, 123, 255, 0.5);
 }
 
@@ -75,7 +203,6 @@ button:hover {
     grid-template-columns: repeat(42, 1fr);
     grid-template-rows: repeat(28, 1fr);
     border: 2px solid #555;
-    /* margin: 0 auto; 已被 flex 布局取代，不再需要 */
 }
 
 /* 单个网格单元 */
@@ -83,25 +210,95 @@ button:hover {
     background-color: transparent;
     background-size: 100% 100%;
     cursor: pointer;
+    position: relative;
+    --tile-color: transparent;
 }
 
-/* 五种状态的样式 (与之前相同) */
-.state-0 {
-    background-image: url('empty.png');
+.grid-cell::after {
+    content: '';
+    position: absolute;
+    inset: 2px;
+    border-radius: 2px;
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-position: center;
+    opacity: 1;
+    transition: opacity 0.2s ease;
 }
 
-.state-1 {
+/* 颜色设置 */
+.color-black {
+    --tile-color: #1f1f1f;
+}
+
+.color-red {
+    --tile-color: #c0392b;
+}
+
+.color-blue {
+    --tile-color: #1f60c0;
+}
+
+/* 基础工具 */
+.tile-empty::after {
+    opacity: 0;
+}
+
+.tile-obstacle::after {
+    background-image: linear-gradient(45deg, rgba(30, 30, 30, 0.8) 25%, transparent 25%, transparent 50%, rgba(30, 30, 30, 0.8) 50%, rgba(30, 30, 30, 0.8) 75%, transparent 75%, transparent);
+    background-size: 12px 12px;
+    background-color: rgba(0, 0, 0, 0.4);
+}
+
+/* 得分块使用 pavement 纹理并根据颜色混合 */
+[class*="tile-score"]::after {
     background-image: url('pavement.png');
+    background-color: var(--tile-color);
+    background-blend-mode: multiply;
 }
 
-.state-2 {
-    background-image: url('tackle_alert.png');
+/* 行进盲道使用纯色块并叠加细纹 */
+[class*="tile-walkway"]::after {
+    background-image: linear-gradient(90deg, rgba(255, 255, 255, 0.2) 20%, transparent 20%, transparent 40%, rgba(255, 255, 255, 0.2) 40%, rgba(255, 255, 255, 0.2) 60%, transparent 60%, transparent 80%, rgba(255, 255, 255, 0.2) 80%);
+    background-size: 12px 12px;
+    background-color: var(--tile-color);
 }
 
-.state-3 {
-    background-image: url('tackle_heng.png');
+/* 提示盲道采用同心纹理 */
+[class*="tile-hint"]::after {
+    background-image: radial-gradient(circle at center, rgba(255, 255, 255, 0.5), transparent 55%),
+        repeating-linear-gradient(45deg, rgba(255, 255, 255, 0.25) 0 6px, transparent 6px 12px);
+    background-color: var(--tile-color);
 }
 
-.state-4 {
-    background-image: url('tackle_shu.png');
+/* 得分块文字颜色稍浅 */
+.palette-cell.tile-score-1,
+.palette-cell.tile-score-2,
+.palette-cell.tile-score-3,
+.palette-cell.tile-score-4,
+.palette-cell.tile-score-5 {
+    color: #fce9b1;
+}
+
+.palette-cell.tile-obstacle {
+    color: #f5f5f5;
+}
+
+/* 响应式处理 */
+@media (max-width: 1200px) {
+    .main-content {
+        flex-direction: column;
+        align-items: center;
+    }
+
+    #palette {
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: center;
+        max-height: none;
+    }
+
+    .palette-section {
+        width: 180px;
+    }
 }


### PR DESCRIPTION
## Summary
- redesign the editor layout with color controls, rotation, and per-player inventory settings
- add palette definitions for scoring tiles, obstacles, movement paths, and hint tiles with rotation support
- track remaining tiles for each player and alert when inventories are exhausted

## Testing
- not run (frontend changes only)

------
https://chatgpt.com/codex/tasks/task_b_68e4ef8a3554832d846c24bb075b5d54